### PR TITLE
Potential fix for code scanning alert no. 1: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/wilco-actions.yml
+++ b/.github/workflows/wilco-actions.yml
@@ -25,7 +25,8 @@ jobs:
 
       - uses: oNaiPs/secrets-to-env-action@v1
         with:
-          secrets: ${{ toJSON(secrets) }}
+          secrets: |
+            WILCO_ENGINE_URL: ${{ secrets.WILCO_ENGINE_URL }}
 
       - name: Wilco checks
         id: Wilco


### PR DESCRIPTION
Potential fix for [https://github.com/Wilcolab/Anythink-Market-gftr0fw8/security/code-scanning/1](https://github.com/Wilcolab/Anythink-Market-gftr0fw8/security/code-scanning/1)

The best way to fix this problem is to avoid passing all secrets via `${{ toJSON(secrets) }}` to the `secrets` input of the `oNaiPs/secrets-to-env-action@v1` step. Instead, enumerate only those secrets that are needed by this workflow, and explicitly list them in the workflow YAML. For example, define an object literal mapping environment variable names to their corresponding secret values, e.g. `WILCO_ENGINE_URL: ${{ secrets.WILCO_ENGINE_URL }}`. If more than one secret is needed, list them all specifically. Edit only lines 28 (and 27, for formatting), ensuring secrets are mapped explicitly, using standard YAML object syntax.

No additional imports, packages, or definitions are needed. The precise change involves replacing the dynamic and insecure `toJSON(secrets)` usage with a hardcoded mapping of exactly the secret keys the workflow actually requires.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
