### PR TITLE
Potential fix for code scanning alert no. 10: Clear text transmission of sensitive cookie

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -28,7 +28,11 @@ app.use(express.static(__dirname + "/public"));
 app.use(
   session({
     secret: "e6F9KvSDf4dyXj",
-    cookie: { maxAge: 60000 },
+    cookie: { 
+      maxAge: 60000,
+      secure: isProduction,
+      httpOnly: true
+    },
     resave: false,
     saveUninitialized: false
   })


### PR DESCRIPTION
Potential fix for [https://github.com/Wilcolab/Anythink-Market-gftr0fw8/security/code-scanning/10](https://github.com/Wilcolab/Anythink-Market-gftr0fw8/security/code-scanning/10)

The fix is to set the `secure` attribute in the session cookie configuration so that cookies are only sent over HTTPS connections. This prevents session hijacking via network sniffing. Since development environments may use plain HTTP, the `secure` flag should only be set to true when running in production (i.e., when `isProduction` is true). To implement this, update the cookie configuration inside the `express-session` initialization at line 31 in `backend/app.js` to conditionally include the `secure` attribute. The cookie options object should be reconfigured to include `secure: isProduction`, and you may also want to include `httpOnly: true` (for additional security, even though it's not required by CodeQL for passing this check).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
